### PR TITLE
Bugfix: Use Composer to find executables

### DIFF
--- a/app/Portman/SourceBuilder.php
+++ b/app/Portman/SourceBuilder.php
@@ -6,6 +6,7 @@ namespace App\Portman;
 
 use App\Portman\Configuration\ConfigurationException;
 use App\Portman\Configuration\Data\Directory;
+use Composer\Autoload\ClassLoader;
 use Illuminate\Console\Command;
 use PhpParser\Error;
 use PhpParser\NodeTraverser;
@@ -176,7 +177,16 @@ class SourceBuilder
 
     protected function findVendorExecutable(string $executable, string $package, Command $command): ?string
     {
-        $rectorPath = (new ExecutableFinder)->find($executable, extraDirs: [BP . 'vendor/bin', 'vendor/bin']);
+        $directories = [BP . 'vendor/bin', 'vendor/bin'];
+
+        if (class_exists(ClassLoader::class)) {
+            $reflection = new \ReflectionClass(ClassLoader::class);
+            $vendorDir = dirname(dirname($reflection->getFileName()));
+
+            $directories[] = $vendorDir . '/bin';
+        }
+
+        $rectorPath = (new ExecutableFinder)->find($executable, extraDirs: $directories);
         if (!$rectorPath) {
             $command->error('Could not find ' . $executable . ', please install it with `composer require --dev ' . $package . '`');
         }


### PR DESCRIPTION
I keep bumping into the issue that whn I run `portman build`, I get these messages:

```
Running Rector
Could not find rector, please install it with `composer require --dev rector/rector`
Running CS-Fixer
Could not find php-cs-fixer, please install it with `composer require --dev friendsofphp/php-cs-fixer`
```

With this PR it forces the `ExecutableFinder` to look into the `vendor/bin` folder, using the location of the `ClassLoader` from Composer itself.